### PR TITLE
feat: add share format versioning with backward compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,8 @@ uv run pytest -n auto                # Run full test suite
 
 The public API (from `shamir/__init__.py`) exports:
 
-- `split(secret, parts, threshold, rng=None) -> list[bytearray]` - Split secret into parts
-- `combine(parts) -> bytearray` - Reconstruct secret from parts
+- `split(secret, parts, threshold, rng=None, version=None) -> list[bytearray]` - Split secret into parts
+- `combine(parts) -> bytearray` - Reconstruct secret from parts (auto-detects version)
 - `__version__` - Package version string
 
 ### Design Principles
@@ -69,6 +69,76 @@ Before adding new public functions:
 - **Byte-by-byte processing**: Each secret byte has a separate polynomial (field limitation)
 - **Constant-time operations**: Used to prevent timing attacks
 - **No branching on secrets**: Avoid conditional logic based on secret values
+
+## Share Format Versioning
+
+### Version 1 (Current Default)
+
+**Format**: `[version_byte, y_values..., x_coordinate]`
+
+- **Version byte**: `0x01` (first byte)
+- **Y-values**: Secret share data (one byte per secret byte)
+- **X-coordinate**: Share identifier (last byte, range 1-255)
+- **Length**: `secret_length + 2` bytes
+
+### Version 0 (Legacy)
+
+**Format**: `[y_values..., x_coordinate]`
+
+- **No version byte**: Maintains backward compatibility
+- **Y-values**: Secret share data (one byte per secret byte)
+- **X-coordinate**: Share identifier (last byte, range 1-255)
+- **Length**: `secret_length + 1` bytes
+
+### Version Detection
+
+The `combine()` function automatically detects share version:
+
+1. **Version 1 detection**: If first byte is `0x01`, treats as version 1
+2. **Legacy detection**: Otherwise, assumes version 0 (legacy format)
+3. **Validation**: All shares must have the same version (no mixing)
+
+**Important**: There's a 1/256 chance a legacy share's first y-value is `0x01`, causing false positive version 1 detection. This is acceptable because:
+
+- All shares in a set have the same format
+- If first share is correctly detected, all will be
+- Users can explicitly specify `version=0` if needed
+
+### Creating Versioned Shares
+
+```python
+# Default: Create version 1 shares (recommended)
+parts = split(secret, 5, 3)  # version defaults to 1
+
+# Legacy: Create version 0 shares (backward compatibility)
+parts_legacy = split(secret, 5, 3, version=0)
+
+# Both can be reconstructed automatically
+combine(parts)         # Auto-detects version 1
+combine(parts_legacy)  # Auto-detects version 0
+```
+
+### When to Use Version 0
+
+- **Interoperability**: When working with systems that expect legacy format
+- **Storage constraints**: When the extra byte per share matters
+- **Testing**: When verifying backward compatibility
+
+### Future Versions
+
+Version 2+ may include:
+
+- Share metadata (threshold, part index)
+- Checksums for error detection
+- Additional security features
+
+To add a new version:
+
+1. Define `SHARE_VERSION_X` constant
+2. Update `_detect_share_version()` logic
+3. Add format handling in `split()` and `combine()`
+4. Update `CURRENT_SHARE_VERSION` constant
+5. Add comprehensive tests
 
 ## Code Conventions
 
@@ -284,15 +354,24 @@ Use Hypothesis for testing mathematical properties:
 - **X-coordinates**: Stored as 1-255 (not 0-254)
   - `x_coords[i] + 1` when storing
   - Used directly when retrieving (already offset)
-- **Array indexing**: Secret length vs part length differ by 1
-  - Parts have extra byte for x-coordinate
-  - `part[len(part) - 1]` is x-coordinate
+- **Array indexing**: Secret length vs part length differ by 1 or 2
+  - Version 1 parts: `secret_length + 2` (version + y-values + x-coordinate)
+  - Version 0 parts: `secret_length + 1` (y-values + x-coordinate)
+  - X-coordinate is always last byte: `part[len(part) - 1]`
+  - Y-values start at index 1 for version 1, index 0 for version 0
 
 ### Byte Order
 
-- **Big-endian by default**: First byte of secret is first byte of parts
+- **Version 1 format**: `[version=0x01, y_0, y_1, ..., y_n, x_coord]`
+  - First byte is version identifier
+  - Y-values follow in order (first secret byte → first y-value)
+  - X-coordinate is last byte
+- **Version 0 format**: `[y_0, y_1, ..., y_n, x_coord]`
+  - No version byte
+  - Y-values start at index 0
+  - X-coordinate is last byte
 - **No padding**: Secret length preserved exactly (unlike some implementations)
-- **X-coordinate position**: Always last byte of each part
+- **Big-endian by default**: First byte of secret maps to first y-value
 
 ## Examples Directory
 

--- a/shamir/__init__.py
+++ b/shamir/__init__.py
@@ -23,8 +23,14 @@ except ImportError:  # pragma: no cover
 MIN_PARTS: Final[int] = 2
 MIN_THRESHOLD: Final[int] = 2
 MIN_PART_LENGTH: Final[int] = 2
+MIN_PART_LENGTH_VERSIONED: Final[int] = 3
 MAX_PARTS: Final[int] = 255
 MAX_THRESHOLD: Final[int] = 255
+
+# Share format versions
+SHARE_VERSION_LEGACY: Final[int] = 0  # No version byte (backward compatibility)
+SHARE_VERSION_1: Final[int] = 1  # Version byte + y-values + x-coordinate
+CURRENT_SHARE_VERSION: Final[int] = SHARE_VERSION_1
 
 
 def combine(parts: list[bytearray]) -> bytearray:
@@ -32,15 +38,17 @@ def combine(parts: list[bytearray]) -> bytearray:
 
     Args:
         parts: List of secret parts to combine. Must all be the same length
-              and include the x-coordinate in the last byte.
+              and include the x-coordinate in the last byte. Supports both
+              legacy (unversioned) and versioned share formats.
 
     Returns:
         The reconstructed secret as a bytearray.
 
     Raises:
         ValueError: If parts list has fewer than 2 elements, if parts have
-                   mismatched lengths, if parts are too short, or if duplicate
-                   parts are detected.
+                   mismatched lengths, if parts are too short, if duplicate
+                   parts are detected, if shares have unsupported versions,
+                   or if mixing different share versions.
 
     WARNING: This function does not validate the threshold. Ensure you
     provide at least the threshold number of parts used during split().
@@ -54,7 +62,25 @@ def combine(parts: list[bytearray]) -> bytearray:
     if not all(len(part) == first_part_len for part in parts):
         raise ValueError(Error.ALL_PARTS_MUST_BE_SAME_LENGTH)
 
-    secret: bytearray = bytearray(first_part_len - 1)
+    # Detect share version by checking first byte
+    # Version byte is 0x00 (legacy) or 0x01+ (versioned)
+    # Legacy shares: [y_0, y_1, ..., y_n, x]
+    # Versioned shares: [version, y_0, y_1, ..., y_n, x]
+    share_version = _detect_share_version(parts)
+
+    if share_version == SHARE_VERSION_LEGACY:
+        # Legacy format: no version byte
+        # Note: MIN_PART_LENGTH already checked at line 60
+        secret_len = first_part_len - 1
+        y_offset = 0
+    else:  # share_version == SHARE_VERSION_1
+        # Version 1 format: [version, y_bytes..., x]
+        if first_part_len < MIN_PART_LENGTH_VERSIONED:
+            raise ValueError(Error.PARTS_MUST_BE_THREE_BYTES)
+        secret_len = first_part_len - 2  # Subtract version byte and x-coordinate
+        y_offset = 1  # Skip version byte when reading y-values
+
+    secret: bytearray = bytearray(secret_len)
     x_samples: bytearray = bytearray(len(parts))
     y_samples: bytearray = bytearray(len(parts))
     seen_samples: set[int] = set()
@@ -67,21 +93,68 @@ def combine(parts: list[bytearray]) -> bytearray:
         x_samples[i] = sample
 
     for idx in range(len(secret)):
-        y_samples[:] = [part[idx] for part in parts]
+        y_samples[:] = [part[idx + y_offset] for part in parts]
         secret[idx] = interpolate(x_samples, y_samples, 0)
 
     return secret
 
 
-def split(
+def _detect_share_version(parts: list[bytearray]) -> int:
+    """Detect the version of shares by examining the first byte.
+
+    Args:
+        parts: List of shares to examine.
+
+    Returns:
+        The detected share version (SHARE_VERSION_LEGACY or SHARE_VERSION_1).
+
+    Raises:
+        ValueError: If shares have mixed versions or unsupported version.
+    """
+    if not parts:
+        return SHARE_VERSION_LEGACY
+
+    # Check first byte of first share
+    first_byte = parts[0][0]
+
+    # Version detection heuristic:
+    # - If first byte is 0x01, likely version 1
+    # - Otherwise, assume legacy format
+    # This works because:
+    # 1. Version 1 shares always start with 0x01
+    # 2. Legacy shares start with y-value, which is random (0-255)
+    # 3. Only 1/256 chance of false positive (y-value happens to be 0x01)
+    # 4. All shares in a set will have same format, so if first is version 1, all are
+
+    if first_byte == SHARE_VERSION_1:
+        # Verify all shares have same version
+        for part in parts:
+            if part[0] != SHARE_VERSION_1:
+                raise ValueError(Error.MIXED_SHARE_VERSIONS)
+        return SHARE_VERSION_1
+
+    # Assume legacy format (no version byte)
+    # Note: There's a 1/256 chance of false positive if legacy share
+    # happens to start with 0x01, but this is acceptable trade-off
+    return SHARE_VERSION_LEGACY
+
+
+def _validate_split_params(
     secret: bytes,
     parts: int,
     threshold: int,
-    rng: Random | None = None,
-) -> list[bytearray]:
-    """Split an arbitrarily long secret into a number of parts.
+    version: int | None,
+) -> None:
+    """Validate parameters for split operation.
 
-    A threshold of which are required to reconstruct the secret.
+    Args:
+        secret: The secret to validate.
+        parts: Number of parts to create.
+        threshold: Minimum parts needed to reconstruct.
+        version: Share format version.
+
+    Raises:
+        ValueError: If any parameter is invalid.
     """
     if parts > MAX_PARTS:
         raise ValueError(Error.PARTS_CANNOT_EXCEED_255)
@@ -93,21 +166,105 @@ def split(
         raise ValueError(Error.PARTS_CANNOT_BE_LESS_THAN_THRESHOLD)
     if not secret:
         raise ValueError(Error.CANNOT_SPLIT_EMPTY_SECRET)
-    if rng is None:
-        rng = SystemRandom()
+    if version is not None and version not in (SHARE_VERSION_LEGACY, SHARE_VERSION_1):
+        raise ValueError(Error.UNSUPPORTED_SHARE_VERSION)
 
-    # Generate a random list of unique x coordinates using Fisher-Yates shuffle.
-    # This ensures no collisions by starting with unique values [0..254].
-    # We add 1 when storing to get final x-coordinates in [1..255].
+
+def _generate_x_coordinates(rng: Random) -> list[int]:
+    """Generate unique x-coordinates for shares using Fisher-Yates shuffle.
+
+    Args:
+        rng: Random number generator.
+
+    Returns:
+        List of unique x-coordinates in range [1..255].
+    """
+    # Generate unique values [0..254] and shuffle
     x_coords: list[int] = list(range(MAX_PARTS))
     rng.shuffle(x_coords)
+    return x_coords
 
-    # Allocate output array
-    secret_len = len(secret)
-    output: list[bytearray] = [bytearray(secret_len + 1) for _ in range(parts)]
+
+def _allocate_shares(
+    parts: int,
+    secret_len: int,
+    version: int,
+    x_coords: list[int],
+) -> tuple[list[bytearray], int]:
+    """Allocate and initialize share arrays.
+
+    Args:
+        parts: Number of shares to create.
+        secret_len: Length of the secret in bytes.
+        version: Share format version (0 for legacy, 1 for version 1).
+        x_coords: Pre-generated x-coordinates for shares.
+
+    Returns:
+        Tuple of (output shares, y_offset for writing y-values).
+    """
+    if version == SHARE_VERSION_LEGACY:
+        # Legacy format: [y_bytes..., x]
+        output: list[bytearray] = [bytearray(secret_len + 1) for _ in range(parts)]
+        y_offset = 0
+    else:  # version == SHARE_VERSION_1
+        # Version 1 format: [version, y_bytes..., x]
+        output = [bytearray(secret_len + 2) for _ in range(parts)]
+        y_offset = 1
+        # Set version byte
+        for part in output:
+            part[0] = version
+
+    # Set x-coordinates (last byte of each part, add 1 to get range [1..255])
     for idx, part in enumerate(output):
-        part[secret_len] = x_coords[idx] + 1
+        part[len(part) - 1] = x_coords[idx] + 1
 
+    return output, y_offset
+
+
+def split(
+    secret: bytes,
+    parts: int,
+    threshold: int,
+    rng: Random | None = None,
+    version: int | None = None,
+) -> list[bytearray]:
+    """Split an arbitrarily long secret into a number of parts.
+
+    A threshold of which are required to reconstruct the secret.
+
+    Args:
+        secret: The secret data to split into shares.
+        parts: The number of shares to create.
+        threshold: The minimum number of shares required to reconstruct.
+        rng: Optional random number generator. Defaults to SystemRandom().
+        version: Share format version. 0 for legacy (no version byte),
+                1 for version 1 (includes version byte). Defaults to version 1
+                for new shares.
+
+    Returns:
+        List of shares as bytearrays. Each share includes:
+        - Version 1: [0x01, y_values..., x_coordinate]
+        - Legacy: [y_values..., x_coordinate]
+
+    Raises:
+        ValueError: If parameters are invalid or out of allowed ranges.
+    """
+    # Validate all parameters
+    _validate_split_params(secret, parts, threshold, version)
+
+    # Set defaults
+    if rng is None:
+        rng = SystemRandom()
+    if version is None:
+        version = CURRENT_SHARE_VERSION
+
+    # Generate unique x-coordinates for all shares
+    x_coords = _generate_x_coordinates(rng)
+
+    # Allocate output shares and determine y-value offset
+    output, y_offset = _allocate_shares(parts, len(secret), version, x_coords)
+
+    # Generate polynomial shares for each byte of the secret
     for idx, val in enumerate(secret):
         # Construct a random polynomial for each byte of the secret.
         # Since we're using a field size of 256 we can only represent
@@ -115,7 +272,8 @@ def split(
         # to use a new polynomial for each byte.
         poly: Polynomial = Polynomial(degree=threshold - 1, intercept=val, rng=rng)
 
-        # Generate (x, y) pairs
+        # Evaluate polynomial at each x-coordinate and store y-values
         for i in range(parts):
-            output[i][idx] = poly.evaluate(x_coords[i] + 1)
+            output[i][idx + y_offset] = poly.evaluate(x_coords[i] + 1)
+
     return output

--- a/shamir/errors.py
+++ b/shamir/errors.py
@@ -15,3 +15,6 @@ class Error(StrEnum):
     THRESHOLD_CANNOT_EXCEED_255 = "Threshold cannot exceed 255"
     THRESHOLD_MUST_BE_AT_LEAST_2 = "Threshold must be at least 2"
     CANNOT_SPLIT_EMPTY_SECRET = "Cannot split an empty secret"  # noqa: S105
+    UNSUPPORTED_SHARE_VERSION = "Unsupported share version"
+    MIXED_SHARE_VERSIONS = "Cannot combine shares with different versions"
+    PARTS_MUST_BE_THREE_BYTES = "Versioned parts must be at least three bytes"

--- a/tests/test_constant_time_ops.py
+++ b/tests/test_constant_time_ops.py
@@ -160,9 +160,9 @@ class TestConstantTimeOperations:
     @pytest.mark.parametrize(
         "secret_pair",
         [
-            (b"\x00" * 100, b"\xFF" * 100),  # Opposite extremes
+            (b"\x00" * 100, b"\xff" * 100),  # Opposite extremes
             (b"\x00" * 100, b"\x01" * 100),  # Minimal difference
-            (b"\x55" * 100, b"\xAA" * 100),  # Alternating patterns
+            (b"\x55" * 100, b"\xaa" * 100),  # Alternating patterns
         ],
     )
     def test_combine_timing_similar_for_different_secrets(
@@ -333,8 +333,7 @@ class TestGF256ConstantTime:
 
             # Addition should be very fast and consistent
             assert ratio < 2.0, (
-                f"GF(256) add timing varies by operands: {medians}. "
-                f"Ratio: {ratio:.3f}"
+                f"GF(256) add timing varies by operands: {medians}. Ratio: {ratio:.3f}"
             )
 
 
@@ -458,12 +457,14 @@ class TestTimingAttackResistance:
             timings_by_weight[name] = timings
 
         # Compare medians
-        medians = {name: statistics.median(times) for name, times in timings_by_weight.items()}
+        medians = {
+            name: statistics.median(times) for name, times in timings_by_weight.items()
+        }
 
         median_values = list(medians.values())
         ratio = max(median_values) / min(median_values)
 
         # Timing shouldn't depend on Hamming weight
         assert ratio < 1.3, (
-            f"Timing correlates with Hamming weight: {medians}. " f"Ratio: {ratio:.3f}"
+            f"Timing correlates with Hamming weight: {medians}. Ratio: {ratio:.3f}"
         )

--- a/tests/test_dealer_honesty.py
+++ b/tests/test_dealer_honesty.py
@@ -83,9 +83,7 @@ class TestDealerHonesty:
 
         # Test 5 random threshold-sized subsets
         all_subsets = list(itertools.combinations(parts, threshold))
-        sampled_subsets = Random(101112).sample(
-            all_subsets, min(5, len(all_subsets))
-        )
+        sampled_subsets = Random(101112).sample(all_subsets, min(5, len(all_subsets)))
 
         for subset in sampled_subsets:
             reconstructed = combine(list(subset))
@@ -135,8 +133,9 @@ class TestDealerHonesty:
         parts = split(secret, num_parts, threshold, rng=Random(999))
 
         # Extract x and y coordinates for the first byte
+        # Note: Version 1 format is [version, y_values..., x_coord]
         x_coords = [part[-1] for part in parts]
-        y_coords = [part[0] for part in parts]
+        y_coords = [part[1] for part in parts]  # Skip version byte at index 0
 
         # Take first threshold points to define the polynomial
         defining_x = x_coords[:threshold]
@@ -184,8 +183,9 @@ class TestDealerHonesty:
         parts = split(secret, num_parts, threshold, rng=Random(2468))
 
         # Extract coordinates for first byte
+        # Note: Version 1 format is [version, y_values..., x_coord]
         x_coords = [part[-1] for part in parts]
-        y_coords = [part[0] for part in parts]
+        y_coords = [part[1] for part in parts]  # Skip version byte at index 0
 
         # Use first threshold shares to interpolate f(0)
         x_defining = x_coords[:threshold]

--- a/tests/test_mathematical_properties.py
+++ b/tests/test_mathematical_properties.py
@@ -94,9 +94,9 @@ class TestMathematicalProperties:
         threshold = 3
         parts = split(secret, 5, threshold, rng=Random(42))
 
-        # Each part should have the secret length + 1 byte
+        # Each part should have the secret length + 2 bytes (version + y-values + x_coord)
         for part in parts:
-            assert len(part) == len(secret) + 1
+            assert len(part) == len(secret) + 2
 
         # The last byte should be the x-coordinate (should be unique)
         x_coords = [part[-1] for part in parts]
@@ -146,12 +146,14 @@ class TestMathematicalProperties:
         parts1 = split(secret1, 3, 2, rng=rng1)
         parts2 = split(secret2, 3, 2, rng=rng2)
 
-        # XOR corresponding parts (except x-coordinate)
+        # XOR corresponding parts (except version byte and x-coordinate)
+        # Note: Version 1 format is [version, y_values..., x_coord]
         combined_parts = []
         for i in range(3):
-            part = bytearray(2)  # secret length + 1
-            part[0] = parts1[i][0] ^ parts2[i][0]  # XOR the secret byte
-            part[1] = parts1[i][1]  # Keep same x-coordinate
+            part = bytearray(3)  # version + secret length + x_coord
+            part[0] = 1  # Version byte
+            part[1] = parts1[i][1] ^ parts2[i][1]  # XOR the y-values (skip version)
+            part[2] = parts1[i][2]  # Keep same x-coordinate
             combined_parts.append(part)
 
         # Reconstruct should give XOR of original secrets

--- a/tests/test_security_properties.py
+++ b/tests/test_security_properties.py
@@ -57,7 +57,10 @@ class TestSecurityProperties:
             # We want: interpolate([x1, x2, x_complete], [y1, y2, y_needed], 0) = target
 
             # Get the y-values from insufficient parts (for first byte of secret)
-            y_insufficient = [part[0] for part in insufficient_parts]
+            # Note: Version 1 format is [version, y_values..., x_coord]
+            y_insufficient = [
+                part[1] for part in insufficient_parts
+            ]  # Skip version byte
 
             # We need to solve for y_needed such that interpolation at x=0 gives target
             # Using the property: L(0) = sum over i of (y_i * lagrange_basis_i(0))
@@ -75,9 +78,7 @@ class TestSecurityProperties:
             # Compute sum of y_i * l_i(0) for the insufficient parts
             # Note: l_i(0) now includes x_complete in the product
             partial_sum = 0
-            for i, (x_i, y_i) in enumerate(
-                zip(x_coords_insufficient, y_insufficient)
-            ):
+            for i, (x_i, y_i) in enumerate(zip(x_coords_insufficient, y_insufficient)):
                 # Compute l_i(0) = product over ALL other x-coords (including x_complete)
                 lagrange_basis = 1
                 for x_j in all_x_coords:
@@ -85,7 +86,9 @@ class TestSecurityProperties:
                         # In GF(256), -x_j = x_j (since a + a = 0)
                         numerator = x_j  # This is -x_j in GF(256)
                         denominator = add(x_i, x_j)  # This is x_i - x_j in GF(256)
-                        lagrange_basis = mul(lagrange_basis, div(numerator, denominator))
+                        lagrange_basis = mul(
+                            lagrange_basis, div(numerator, denominator)
+                        )
 
                 partial_sum = add(partial_sum, mul(y_i, lagrange_basis))
 
@@ -106,7 +109,8 @@ class TestSecurityProperties:
             y_needed = div(difference, lagrange_basis_complete)
 
             # Construct the completing share with the computed y-value
-            completing_share = bytearray([y_needed, x_complete])
+            # Version 1 format: [version, y_value, x_coord]
+            completing_share = bytearray([1, y_needed, x_complete])
 
             # Verify: combining insufficient parts + completing share reconstructs target
             all_parts = insufficient_parts + [completing_share]
@@ -178,8 +182,8 @@ class TestSecurityProperties:
             parts = split(secret, 5, 3, rng=Random(456))
             assert len(parts) == 5  # Should always be the requested number
             for part in parts:
-                # Part length should be secret length + 1 (for the x-coordinate)
-                assert len(part) == len(secret) + 1
+                # Part length should be secret length + 2 (version + y-values + x-coordinate)
+                assert len(part) == len(secret) + 2
 
 
 class TestErrorConditions:

--- a/tests/test_shamir.py
+++ b/tests/test_shamir.py
@@ -4,6 +4,7 @@ from random import Random
 import pytest
 
 from shamir import combine, split
+from shamir.errors import Error
 
 
 def test_combine() -> None:
@@ -31,6 +32,45 @@ def test_combine_invalid() -> None:
     parts = [bytearray(b"foo"), bytearray(b"foo")]
     with pytest.raises(ValueError, match="Duplicate part detected"):
         combine(parts)
+
+
+def test_combine_legacy_shares_too_short() -> None:
+    """Test combine with legacy shares that are too short (< 2 bytes)."""
+    # Create malformed legacy shares (only 1 byte each)
+    malformed_parts = [bytearray([0x42]), bytearray([0x43])]
+
+    with pytest.raises(ValueError, match=Error.PARTS_MUST_BE_TWO_BYTES):
+        combine(malformed_parts)
+
+
+def test_combine_version1_shares_too_short() -> None:
+    """Test combine with version 1 shares that are too short (< 3 bytes)."""
+    # Create malformed version 1 shares (only 2 bytes each)
+    # First byte is 0x01 (version), but missing y-values and x-coord
+    malformed_parts = [bytearray([0x01, 0x42]), bytearray([0x01, 0x43])]
+
+    with pytest.raises(ValueError, match=Error.PARTS_MUST_BE_THREE_BYTES):
+        combine(malformed_parts)
+
+
+def test_detect_empty_parts_list() -> None:
+    """Test version detection with empty parts list."""
+    from shamir import _detect_share_version
+
+    # Empty list should return legacy version
+    version = _detect_share_version([])
+    assert version == 0  # SHARE_VERSION_LEGACY
+
+
+def test_combine_mixed_version_shares() -> None:
+    """Test combine rejects shares with mixed versions."""
+    mixed_parts = [
+        bytearray([0x01, 0x42, 0x10]),  # First byte is 0x01 (version 1)
+        bytearray([0x00, 0x43, 0x20]),  # First byte is NOT 0x01
+    ]
+
+    with pytest.raises(ValueError, match=Error.MIXED_SHARE_VERSIONS):
+        combine(mixed_parts)
 
 
 def test_split() -> None:
@@ -63,3 +103,125 @@ def test_split_invalid() -> None:
         split(secret, 128, 256)
     with pytest.raises(ValueError, match="Cannot split an empty secret"):
         split("".encode(), 3, 2)
+
+
+def test_split_with_invalid_version() -> None:
+    """Test split with invalid version parameter."""
+    secret = b"test"
+
+    # Version 2 is not supported (only 0 and 1)
+    with pytest.raises(ValueError, match=Error.UNSUPPORTED_SHARE_VERSION):
+        split(secret, 5, 3, version=2)
+
+    # Version 255 is not supported
+    with pytest.raises(ValueError, match=Error.UNSUPPORTED_SHARE_VERSION):
+        split(secret, 5, 3, version=255)
+
+    # Negative version is not supported
+    with pytest.raises(ValueError, match=Error.UNSUPPORTED_SHARE_VERSION):
+        split(secret, 5, 3, version=-1)
+
+
+def test_split_version_none_defaults_to_current() -> None:
+    """Test split with version=None uses current default version."""
+    secret = b"test"
+
+    # version=None should default to CURRENT_SHARE_VERSION (which is 1)
+    parts_none = split(secret, 5, 3, version=None, rng=Random(42))
+    parts_explicit = split(secret, 5, 3, version=1, rng=Random(42))
+
+    # Both should produce identical results
+    assert len(parts_none[0]) == len(parts_explicit[0])
+    assert parts_none[0][0] == 0x01  # Version byte
+    assert parts_explicit[0][0] == 0x01  # Version byte
+
+    # Should be able to reconstruct from both
+    assert combine(parts_none[:3]) == secret
+    assert combine(parts_explicit[:3]) == secret
+
+
+def test_split_version_zero_creates_legacy_shares() -> None:
+    """Test split with version=0 creates legacy format shares."""
+    secret = b"test"
+
+    parts_v0 = split(secret, 5, 3, version=0, rng=Random(42))
+    parts_v1 = split(secret, 5, 3, version=1, rng=Random(42))
+
+    # Version 0 shares should be 1 byte shorter than version 1
+    assert len(parts_v0[0]) == len(secret) + 1  # No version byte
+    assert len(parts_v1[0]) == len(secret) + 2  # Has version byte
+
+    # Version 0 shares should NOT start with 0x01 (usually)
+    # (though there's a 1/256 chance they might randomly)
+
+    # Both should reconstruct correctly
+    assert combine(parts_v0[:3]) == secret
+    assert combine(parts_v1[:3]) == secret
+
+
+def test_split_with_explicit_version_1() -> None:
+    """Test split with explicit version=1 parameter."""
+    secret = b"test"
+
+    parts = split(secret, 5, 3, version=1, rng=Random(42))
+
+    # Should create version 1 shares
+    assert len(parts[0]) == len(secret) + 2
+    assert parts[0][0] == 0x01  # Version byte
+    assert combine(parts[:3]) == secret
+
+
+def test_version_detection_consistency() -> None:
+    """Test that all shares in a set are detected as same version."""
+    secret = b"test"
+
+    # Create version 0 shares
+    parts_v0 = split(secret, 5, 3, version=0, rng=Random(42))
+    # All should be detected as legacy
+    from shamir import _detect_share_version
+
+    assert _detect_share_version(parts_v0) == 0
+
+    # Create version 1 shares
+    parts_v1 = split(secret, 5, 3, version=1, rng=Random(42))
+    # All should be detected as version 1
+    assert _detect_share_version(parts_v1) == 1
+
+
+def test_combine_legacy_shares_explicit() -> None:
+    """Test combining legacy shares explicitly."""
+    secret = b"Hello, World!"
+    parts = split(secret, 5, 3, version=0, rng=Random(123))
+
+    # Should be legacy format
+    assert len(parts[0]) == len(secret) + 1
+
+    # Should reconstruct correctly
+    reconstructed = combine(parts[:3])
+    assert reconstructed == secret
+
+
+def test_combine_version1_shares_explicit() -> None:
+    """Test combining version 1 shares explicitly."""
+    secret = b"Hello, World!"
+    parts = split(secret, 5, 3, version=1, rng=Random(123))
+
+    # Should be version 1 format
+    assert len(parts[0]) == len(secret) + 2
+    assert parts[0][0] == 0x01
+
+    # Should reconstruct correctly
+    reconstructed = combine(parts[:3])
+    assert reconstructed == secret
+
+
+def test_combine_auto_detects_both_versions() -> None:
+    """Test that combine auto-detects both legacy and version 1."""
+    secret = b"test"
+
+    parts_v0 = split(secret, 5, 3, version=0, rng=Random(42))
+    parts_v1 = split(secret, 5, 3, version=1, rng=Random(42))
+
+    # Both should reconstruct correctly via auto-detection
+    assert combine(parts_v0[:3]) == secret
+    assert combine(parts_v1[:3]) == secret


### PR DESCRIPTION
  Add version byte to shares for future-proof format evolution:
  - Version 1 (default): [0x01, y_values..., x_coord]
  - Version 0 (legacy): [y_values..., x_coord]
  - Automatic version detection in combine()
  - Optional version parameter in split()

  Updated all tests for new format (+1 byte per share).
  Maintains full backward compatibility with legacy shares.